### PR TITLE
Feat/pp 10 i18n localization

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -179,6 +179,7 @@ Documentation Requirements
   - Explain business rules
   - Note edge cases
   - TSDoc for exported functions
+- create and update *.md refer to markdownlint to ensure valid markdown
 
 Monitoring and Analytics
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -5,7 +5,7 @@ You are a Principal Fullstack Developer and expert in TypeScript, Javascript, No
 - Follow the user’s requirements carefully & to the letter.
 - First think step-by-step - describe your plan for what to build in pseudocode, written out in great detail.
 - Confirm, then write code!
-- Always write correct, best practice, DRY principle (Dont Repeat Yourself), bug free, fully functional and working code also it should be aligned to listed rules down below at Code Implementation Guidelines .
+- Always write correct, best practice, DRY principle (Dont Repeat Yourself), bug free, fully functional and working code also it should be aligned to listed rules down below at Code Implementation Guidelines.
 - Focus on easy and readability code, over being performant.
 - Fully implement all requested functionality.
 - Leave NO todo’s, placeholders or missing pieces.
@@ -156,7 +156,7 @@ Accessibility Standards
 Version Control and Git Workflow
 
 - Branch naming: feature/, bugfix/, hotfix/, release/
-- Commit message format: 
+- Commit message format:
   - type(scope): description
   - Types: feat, fix, docs, style, refactor, test, chore
 - Pull request requirements:

--- a/README.md
+++ b/README.md
@@ -48,9 +48,42 @@ A modern, full-stack web application built with PayloadCMS 3.0 and Next.js 15.
 │       ├── blocks/         # Content blocks
 │       ├── collections/    # Database collections
 │       ├── i18n/          # Internationalization
+│           ├── routing.ts  # i18n routing configuration
+│           └── i18n.ts     # PayloadCMS i18n config
 │       ├── plugins/       # PayloadCMS plugins
 │       └── utils/         # CMS utilities
 ```
+
+## Internationalization (i18n)
+
+The project uses a dual i18n setup:
+
+- PayloadCMS Admin UI translations (en, de)
+- Next.js frontend translations using next-intl
+
+### Supported Languages
+
+- English (en) - Default
+- German (de)
+
+### Collection Fields
+
+Localized fields in collections are marked with:
+
+```typescript
+{
+  name: 'title',
+  type: 'text',
+  localized: true
+}
+```
+
+### Configuration Files
+
+- `src/payload/i18n/i18n.ts` - PayloadCMS admin translations
+- `src/payload/i18n/messages/` - Frontend translation files
+- `src/payload/i18n/routing.ts` - i18n routing setup
+- `src/payload/i18n/request.ts` - next-intl configuration
 
 ## Collections
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,118 @@
-# payload-playground
-Playground for payload cms
+# PayloadCMS Playground
+
+A modern, full-stack web application built with PayloadCMS 3.0 and Next.js 15.
+
+## Technology Stack
+
+### Frontend
+
+- Next.js 15 (App Router)
+- React 19
+- TypeScript
+- TailwindCSS
+- Shadcn UI
+- Radix UI
+
+### Backend & CMS
+
+- PayloadCMS 3.0
+- PostgreSQL (via Docker)
+- Node.js (^18.20.2 || >=20.9.0)
+
+### Infrastructure
+
+- Docker for local development
+- AWS S3 (media storage)
+- AWS CloudFront (CDN)
+- AWS Route53 (DNS)
+- Vercel (hosting)
+- Vercel Edge Functions
+
+### Development Tools
+
+- PNPM (package manager)
+- ESLint
+- Prettier
+- TypeScript
+- Next-intl (internationalization)
+
+## Project Structure
+
+```shell
+.
+├── src/
+│   ├── app/                 # Next.js app router pages
+│   ├── components/          # Shared React components
+│   ├── lib/                 # Utility functions
+│   └── payload/            # PayloadCMS configuration
+│       ├── blocks/         # Content blocks
+│       ├── collections/    # Database collections
+│       ├── i18n/          # Internationalization
+│       ├── plugins/       # PayloadCMS plugins
+│       └── utils/         # CMS utilities
+```
+
+## Collections
+
+- Users
+- Media
+- Pages
+- Posts
+- Categories
+- Newsletter
+
+## Features
+
+- 🌐 Internationalization (i18n) support
+- 📝 Rich text editing with Lexical Editor
+- 🔍 SEO optimization with PayloadCMS SEO plugin
+- 🖼️ Media management
+- 📱 Responsive design
+- 🔒 Authentication and authorization
+- 🚀 Server-side rendering
+- 📊 Content versioning
+
+## Getting Started
+
+1. Clone the repository
+2. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+3. Start PostgreSQL:
+
+   ```bash
+   pnpm start:postgres
+   ```
+
+4. Run the development server:
+
+   ```bash
+   pnpm dev
+   ```
+
+5. Open [http://localhost:3000](http://localhost:3000) in your browser
+
+## Environment Variables
+
+Create a `.env` file in the root directory with the following variables:
+
+```properties
+PAYLOAD_SECRET=your-secret-key
+DATABASE_URI=postgres://postgres:postgres@localhost:5432/payload
+```
+
+## Scripts
+
+- `pnpm dev` - Start development server
+- `pnpm build` - Build for production
+- `pnpm start` - Start production server
+- `pnpm generate:types` - Generate PayloadCMS types
+- `pnpm start:postgres` - Start PostgreSQL container
+- `pnpm stop:postgres` - Stop PostgreSQL container
+
+## License
+
+MIT

--- a/src/payload/blocks/quote-block.ts
+++ b/src/payload/blocks/quote-block.ts
@@ -11,10 +11,12 @@ export const QuoteBlock: Block = {
       name: 'quoteHeader',
       type: 'text',
       required: true,
+      localized: true,
     },
     {
       name: 'quoteText',
       type: 'text',
+      localized: true,
     },
   ],
 }

--- a/src/payload/collections/Categories.ts
+++ b/src/payload/collections/Categories.ts
@@ -4,14 +4,50 @@ export const Categories: CollectionConfig = {
   slug: 'categories',
   admin: {
     useAsTitle: 'title',
+    defaultColumns: ['title', 'slug', 'publishedAt', 'status'],
   },
   access: {
     read: () => true,
+  },
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 100, // We set this interval for optimal live preview
+      },
+      schedulePublish: true,
+    },
+    maxPerDoc: 50,
   },
   fields: [
     {
       name: 'title',
       type: 'text',
+      localized: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      localized: true,
+    },
+    {
+      name: 'publishedAt',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+        position: 'sidebar',
+      },
+      hooks: {
+        beforeChange: [
+          ({ siblingData, value }) => {
+            if (siblingData._status === 'published' && !value) {
+              return new Date()
+            }
+            return value
+          },
+        ],
+      },
     },
   ],
 }

--- a/src/payload/collections/Pages.ts
+++ b/src/payload/collections/Pages.ts
@@ -14,6 +14,16 @@ export const Pages: CollectionConfig = {
   slug: 'pages',
   admin: {
     useAsTitle: 'title',
+    defaultColumns: ['title', 'slug', 'publishedAt', 'status'],
+  },
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 100, // We set this interval for optimal live preview
+      },
+      schedulePublish: true,
+    },
+    maxPerDoc: 50,
   },
   fields: [
     {
@@ -21,12 +31,14 @@ export const Pages: CollectionConfig = {
       label: 'Title',
       type: 'text',
       required: true,
+      localized: true,
     },
     {
       name: 'slug',
       type: 'text',
       label: 'Slug',
       required: true,
+      localized: true,
     },
     {
       type: 'tabs',
@@ -98,13 +110,4 @@ export const Pages: CollectionConfig = {
     },
   ],
   hooks: {},
-  versions: {
-    drafts: {
-      autosave: {
-        interval: 100, // We set this interval for optimal live preview
-      },
-      schedulePublish: true,
-    },
-    maxPerDoc: 50,
-  },
 }

--- a/src/payload/collections/Posts.ts
+++ b/src/payload/collections/Posts.ts
@@ -14,6 +14,16 @@ export const Posts: CollectionConfig = {
   slug: 'posts',
   admin: {
     useAsTitle: 'title',
+    defaultColumns: ['title', 'slug', 'publishedAt', 'status'],
+  },
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 100, // We set this interval for optimal live preview
+      },
+      schedulePublish: true,
+    },
+    maxPerDoc: 50,
   },
   fields: [
     {
@@ -21,12 +31,14 @@ export const Posts: CollectionConfig = {
       label: 'Title',
       type: 'text',
       required: true,
+      localized: true,
     },
     {
       name: 'slug',
       type: 'text',
       label: 'Slug',
       required: true,
+      localized: true,
     },
     {
       type: 'tabs',
@@ -148,13 +160,4 @@ export const Posts: CollectionConfig = {
     },
   ],
   hooks: {},
-  versions: {
-    drafts: {
-      autosave: {
-        interval: 100, // We set this interval for optimal live preview
-      },
-      schedulePublish: true,
-    },
-    maxPerDoc: 50,
-  },
 }

--- a/src/payload/i18n/localization.ts
+++ b/src/payload/i18n/localization.ts
@@ -1,0 +1,23 @@
+import type { I18nOptions } from '@payloadcms/translations'
+import { en } from '@payloadcms/translations/languages/en'
+import { de } from '@payloadcms/translations/languages/de'
+
+export const i18n: I18nOptions = {
+  fallbackLanguage: 'en', // default
+  supportedLanguages: { en, de },
+}
+
+export const localization = {
+  locales: [
+    {
+      label: 'English',
+      code: 'en',
+    },
+    {
+      label: 'Deutsch',
+      code: 'de',
+    },
+  ],
+  defaultLocale: 'en', // required
+  fallback: true, // defaults to true
+}

--- a/src/payload/i18n/routing.ts
+++ b/src/payload/i18n/routing.ts
@@ -1,0 +1,14 @@
+import { defineRouting } from 'next-intl/routing'
+import { createNavigation } from 'next-intl/navigation'
+import { localization } from '@/payload/i18n/localization'
+
+export const routing = defineRouting({
+  locales: localization.locales.map((locale) => locale.code),
+  defaultLocale: localization.defaultLocale,
+})
+
+// Lightweight wrappers around Next.js' navigation APIs
+// that will consider the routing configuration
+export const { Link, redirect, usePathname, useRouter } = createNavigation(routing)
+
+export type Locale = (typeof routing.locales)[number]

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -40,7 +40,7 @@ export interface Config {
   };
   globals: {};
   globalsSelect: {};
-  locale: null;
+  locale: 'en' | 'de';
   user: User & {
     collection: 'users';
   };
@@ -157,8 +157,11 @@ export interface Post {
 export interface Category {
   id: number;
   title?: string | null;
+  slug?: string | null;
+  publishedAt?: string | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -425,8 +428,11 @@ export interface PostsSelect<T extends boolean = true> {
  */
 export interface CategoriesSelect<T extends boolean = true> {
   title?: T;
+  slug?: T;
+  publishedAt?: T;
   updatedAt?: T;
   createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -555,6 +561,10 @@ export interface TaskSchedulePublish {
       | ({
           relationTo: 'posts';
           value: number | Post;
+        } | null)
+      | ({
+          relationTo: 'categories';
+          value: number | Category;
         } | null);
     global?: string | null;
     user?: (number | null) | User;

--- a/src/payload/payload.config.ts
+++ b/src/payload/payload.config.ts
@@ -15,8 +15,7 @@ import { Posts } from '@/payload/collections/Posts'
 import { Categories } from '@/payload/collections/Categories'
 import { Newsletter } from '@/payload/collections/Newsletter'
 
-import { en } from '@payloadcms/translations/languages/en'
-import { de } from '@payloadcms/translations/languages/de'
+import { i18n, localization } from '@/payload/i18n/localization'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -39,10 +38,8 @@ export default buildConfig({
       connectionString: process.env.DATABASE_URI || '',
     },
   }),
-  i18n: {
-    fallbackLanguage: 'en', // default
-    supportedLanguages: { en, de },
-  },
+  i18n,
+  localization,
   sharp,
   plugins: [...plugins],
 })


### PR DESCRIPTION
Enhance internationalization support and update documentation
- Added dual i18n setup for PayloadCMS and Next.js with support for English and German.
- Updated README.md to include details on internationalization configuration and supported languages.
- Modified payload-types.ts to specify locale types.
- Enhanced Categories, Posts, and Pages collections with localized fields and scheduling options for drafts.
- Updated quote-block to support localization.
- Added markdownlint reference in .cursorrules for markdown validation.